### PR TITLE
Add configuration file

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-xboxdrv (20140424-1) trusty; urgency=low
+
+  * Adding support for options under /etc/default.
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Thu, 24 Apr 2014 23:40:50 -0300
+
 ubuntu-xboxdrv (20140423-1) trusty; urgency=low
 
   * Fixing missing license.
@@ -8,25 +14,25 @@ ubuntu-xboxdrv (20140421-1) trusty; urgency=low
 
   * Fixing typo in package description.
 
- -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Wed, 21 Apr 2014 15:13:23 -0300
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Mon, 21 Apr 2014 15:13:23 -0300
 
 ubuntu-xboxdrv (20140420-1) trusty; urgency=low
 
   * Enabling autocomplete in sudo service xboxdrv <command>.
 
- -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Wed, 20 Apr 2014 15:01:01 -0300
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Sun, 20 Apr 2014 15:01:01 -0300
 
 ubuntu-xboxdrv (20140419-1) trusty; urgency=low
 
   * Fixing resume/suspend script placement.
 
- -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Wed, 19 Apr 2014 00:01:34 -0300
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Sat, 19 Apr 2014 00:01:34 -0300
 
 ubuntu-xboxdrv (20140418-1) trusty; urgency=low
 
   * At resume/suspend, restarting xboxdrv daemon.
 
- -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Wed, 18 Apr 2014 16:50:40 -0300
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Fri, 18 Apr 2014 16:50:40 -0300
 
 ubuntu-xboxdrv (20140416-1) trusty; urgency=low
 

--- a/src/debian/install
+++ b/src/debian/install
@@ -1,3 +1,4 @@
 etc/init/xboxdrv.conf etc/init
+etc/default/xboxdrv /etc/default
 etc/pm/sleep.d/xboxdrv /etc/pm/sleep.d
 usr/share/applications/unity-joystick-panel.desktop usr/share/applications

--- a/src/etc/default/xboxdrv
+++ b/src/etc/default/xboxdrv
@@ -1,0 +1,4 @@
+# Defaults for xboxdrv service
+
+# Additional options that are passed to xboxdrv (see xboxdrv man pages).
+XBOXDRV_OPTIONS=""

--- a/src/etc/init/xboxdrv.conf
+++ b/src/etc/init/xboxdrv.conf
@@ -3,4 +3,12 @@ start on filesystem
 pre-start script
     rm -f /dev/input/js*
 end script
-exec xboxdrv --daemon --detach-kernel-driver --silent --dbus disabled
+script
+    # Edit /etc/default/xboxdrv to change extra options
+    XBOXDRV_OPTIONS=""
+    # Read configuration variable file if it is present
+    if [ -f /etc/default/xboxdrv ] ; then
+        . /etc/default/xboxdrv
+    fi
+    xboxdrv --daemon --detach-kernel-driver --silent --dbus disabled $XBOXDRV_OPTIONS
+end script


### PR DESCRIPTION
It is a good idea add a configuration file (like /etc/default/xboxdrv) to allow user set some xboxdrv options. For example, I use a Play 2 control, and I need to pass a lot options to xboxdrv to remap buttons. A file for do that will be nice.
