### PR TITLE
D-Bus not work

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-xboxdrv (20140529-1) trusty; urgency=low
+
+  * Disabling again dbus integration.
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Thu, 29 May 2014 13:39:58 -0300
+
 ubuntu-xboxdrv (20140526-1) trusty; urgency=low
 
   * Enabling dbus integration.

--- a/src/etc/init/xboxdrv.conf
+++ b/src/etc/init/xboxdrv.conf
@@ -10,5 +10,5 @@ script
     if [ -f /etc/default/xboxdrv ] ; then
         . /etc/default/xboxdrv
     fi
-    xboxdrv --daemon --silent $XBOXDRV_OPTIONS --detach-kernel-driver --next-controller --detach-kernel-driver --next-controller --detach-kernel-driver --next-controller --detach-kernel-driver
+    xboxdrv --daemon --silent --dbus disabled $XBOXDRV_OPTIONS --detach-kernel-driver --next-controller --detach-kernel-driver --next-controller --detach-kernel-driver --next-controller --detach-kernel-driver
 end script


### PR DESCRIPTION
I try to run xboxdrvctl -S (use dbus) and this error occurs:
Traceback (most recent call last):
  File "/usr/bin/xboxdrvctl", line 72, in <module>
    daemon = bus.get_object("org.seul.Xboxdrv", '/org/seul/Xboxdrv/Daemon')
  File "/usr/lib/python2.7/dist-packages/dbus/bus.py", line 241, in get_object
    follow_name_owner_changes=follow_name_owner_changes)
  File "/usr/lib/python2.7/dist-packages/dbus/proxies.py", line 248, in **init**
    self._named_service = conn.activate_name_owner(bus_name)
  File "/usr/lib/python2.7/dist-packages/dbus/bus.py", line 180, in activate_name_owner
    self.start_service_by_name(bus_name)
  File "/usr/lib/python2.7/dist-packages/dbus/bus.py", line 278, in start_service_by_name
    'su', (bus_name, flags)))
  File "/usr/lib/python2.7/dist-packages/dbus/connection.py", line 651, in call_blocking
    message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name org.seul.Xboxdrv was not provided by any .service files

I think is some connection between dbus and systemd, because systemd use .service files.
