### PR TITLE
Fix package creation warnings

### DIFF
--- a/src/debian/control
+++ b/src/debian/control
@@ -2,15 +2,13 @@ Source: ubuntu-xboxdrv
 Section: utils
 Priority: optional
 Maintainer: Rael G.C. <rael.gc@gmail.com>
-Build-Depends: debhelper (>= 8.0.0)
-Standards-Version: 3.9.4
+Build-Depends: debhelper (>= 9)
+Standards-Version: 3.9.5
 Homepage: https://launchpad.net/~rael-gc/+archive/ubuntu-xboxdrv
-#Vcs-Git: git://git.debian.org/collab-maint/ubuntu-xboxdrv.git
-#Vcs-Browser: http://git.debian.org/?p=collab-maint/ubuntu-xboxdrv.git;a=summary
 
 Package: ubuntu-xboxdrv
 Architecture: all
-Depends: xboxdrv, jstest-gtk
+Depends: ${misc:Depends}, xboxdrv, jstest-gtk
 Description: Creates a xboxdrv daemon and Joysticks in System Settings
  xboxdrv is installed in Ubuntu without proper daemon configuration.
  This package creates a proper daemon and an entry named "Joystick"


### PR DESCRIPTION
The following warnings are generated during package creation:

```
W: ubuntu-xboxdrv source: debhelper-but-no-misc-depends ubuntu-xboxdrv
W: ubuntu-xboxdrv source: package-needs-versioned-debhelper-build-depends 9
W: ubuntu-xboxdrv source: out-of-date-standards-version 3.9.4 (current is 3.9.5)
```

Fix them.
