### PR TITLE
A typo in xboxdrv.conf

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-xboxdrv (20140626-1) trusty; urgency=low
+
+  * Fixing missing equal sign (=) on /etc/init/xboxdrv.conf
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Thu, 26 Jun 2014 09:40:28 -0300
+
 ubuntu-xboxdrv (20140617-1) trusty; urgency=low
 
   * Enabling --mimic-xpad and --mimic-xpad-wireless

--- a/src/etc/init/xboxdrv.conf
+++ b/src/etc/init/xboxdrv.conf
@@ -29,6 +29,6 @@ script
         XBOXDRV_DAEMON_OPTIONS="$XBOXDRV_DAEMON_OPTIONS --trigger-as-button"
     fi
     # User additional options
-    XBOXDRV_DAEMON_OPTIONS="$XBOXDRV_DAEMON_OPTIONS $XBOXDRV_OPTIONS="
+    XBOXDRV_DAEMON_OPTIONS="$XBOXDRV_DAEMON_OPTIONS $XBOXDRV_OPTIONS"
     xboxdrv --daemon --silent --dbus disabled $XBOXDRV_DAEMON_OPTIONS --detach-kernel-driver --next-controller --detach-kernel-driver --next-controller --detach-kernel-driver --next-controller --detach-kernel-driver
 end script


### PR DESCRIPTION
The = shouldn't be there (after $XBOXDRV_OPTIONS): https://github.com/raelgc/ubuntu_xboxdrv/blob/master/src/etc/init/xboxdrv.conf#L32

Otherwise Xboxdrv stops working if you have custom options specified.
