### PR TITLE
Check presence of update-desktop-database

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-xboxdrv (20141102-1) trusty; urgency=low
+
+  * Checking presence of update-desktop-database
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Sun, 02 Nov 2014 11:17:22 -0200
+
 ubuntu-xboxdrv (20140707-1) trusty; urgency=low
 
   * Fixing missing options on /etc/init/xboxdrv.conf

--- a/src/debian/postinst
+++ b/src/debian/postinst
@@ -21,7 +21,9 @@ set -e
 case "$1" in
     configure)
         # Update entries in System Settings
-        update-desktop-database
+        if (which update-desktop-database); then
+            update-desktop-database
+        fi
         # Creating an /etc/init.d entry to enable auto completion
         ln -sf /etc/init/xboxdrv.conf /etc/init.d/xboxdrv
         # Start xboxdrv daemon

--- a/src/debian/postrm
+++ b/src/debian/postrm
@@ -22,7 +22,9 @@ set -e
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
         # Updating System Settings after removal
-        update-desktop-database
+        if (which update-desktop-database); then
+            update-desktop-database
+        fi
         # Removing symlink from /etc/init.d folder
         rm -f /etc/init.d/xboxdrv
     ;;


### PR DESCRIPTION
Some customers complained about the `post-inst` behavior, when `update-desktop-database` is called but do not exists.
