### PR TITLE
Repeat default options for all controllers

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-xboxdrv (20141113-1) trusty; urgency=low
+
+  * Fixing typo on service init: "detache"
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Thu, 13 Nov 2014 09:43:22 -0200
+
 ubuntu-xboxdrv (20141112-1) trusty; urgency=low
 
   * Fixing #22: Repeat default options for all controllers

--- a/src/etc/init/xboxdrv.conf
+++ b/src/etc/init/xboxdrv.conf
@@ -29,6 +29,6 @@ script
         PAD_OPTIONS="$PAD_OPTIONS --trigger-as-button"
     fi
     # Adding --detache-kernel-driver
-    PAD_OPTIONS="$PAD_OPTIONS --detache-kernel-driver"
+    PAD_OPTIONS="$PAD_OPTIONS --detach-kernel-driver"
     xboxdrv --daemon --silent --dbus disabled $XBOXDRV_OPTIONS $PAD_OPTIONS --next-controller $PAD_OPTIONS --next-controller $PAD_OPTIONS --next-controller $PAD_OPTIONS
 end script


### PR DESCRIPTION
Actually all the options (to mimic xpad, force_feedback, etc) are valid only for the first controller.

Rework init to enable the same configurations for default for all controllers.
