### PR TITLE
doesn't uninstall when service isn't running

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-xboxdrv (20150105-1) trusty; urgency=low
+
+  * Fixes #25: Silently stopping the service on package remove
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Mon, 05 Jan 2015 09:38:21 -0200
+
 ubuntu-xboxdrv (20141231-1) trusty; urgency=low
 
   * Fixes #24: Replacing power management command

--- a/src/debian/prerm
+++ b/src/debian/prerm
@@ -19,10 +19,8 @@ set -e
 
 case "$1" in
     remove|upgrade|deconfigure)
-        if ps -d | grep "xboxdrv" > /dev/null
-        then
-            service xboxdrv stop
-        fi
+        # Silently stoping the service
+        stop -q xboxdrv || :
     ;;
 
     failed-upgrade)


### PR DESCRIPTION
I didn't had the service `xboxdrv` running, now when I try to uninstall it I get the following error:

```
Removing ubuntu-xboxdrv (20141231-1) ...
stop: Unknown instance: 
dpkg: error processing package ubuntu-xboxdrv (--remove):
 subproces installed pre-removal script gaf een foutwaarde 1 terug
Fouten gevonden tijdens behandelen van:
 ubuntu-xboxdrv
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

The uninstaller seems to be expecting that the service is running and breaks because of it.