### PR TITLE
Update xboxdrv, added notice for XBMC

### DIFF
--- a/src/etc/default/xboxdrv
+++ b/src/etc/default/xboxdrv
@@ -3,7 +3,7 @@
 # If enabled, can present problems on wine games
 FORCE_FEEDBACK=false
 
-# Make triggers work like buttons instead of zaxis
+# Make triggers work like buttons instead of zaxis (disable this for XBMC version 13)
 TRIGGER_AS_BUTTON=true
 
 # Mimic xpad buttons


### PR DESCRIPTION
In order to get a working keymapping for XBMC, TRIGGER_AS_BUTTON has to be disabled.
This was tested on Debian Jessie with XBMC 13.2 Gotham from Debian repo.
I don't know if this should be disabled for other versions like Kodi 14 or Kodi 15, too.